### PR TITLE
fix: パン操作時にgripColorがリセットされるバグを修正

### DIFF
--- a/Sources/WHSheetViewController/WHSheetViewController.swift
+++ b/Sources/WHSheetViewController/WHSheetViewController.swift
@@ -175,6 +175,9 @@ public class WHSheetViewController: UIViewController {
     private var panGestureRecognizer: InitialTouchPanGestureRecognizer!
     private var prePanHeight: CGFloat = 0
     private var isPanning: Bool = false
+    private var prePanGripColor: UIColor?
+    private var prePanPullBarBackgroundColor: UIColor?
+    private var prePanCornerRadius: CGFloat = 12
 
     public var contentBackgroundColor: UIColor? {
         get { self.contentViewController.contentBackgroundColor }
@@ -465,6 +468,9 @@ public class WHSheetViewController: UIViewController {
             self.firstPanPoint = point
             self.prePanHeight = self.contentViewController.view.bounds.height
             self.isPanning = true
+            self.prePanGripColor = self.gripColor
+            self.prePanPullBarBackgroundColor = self.pullBarBackgroundColor
+            self.prePanCornerRadius = self.cornerRadius
         }
 
         let minHeight: CGFloat = self.height(for: self.orderedSizes.first)
@@ -492,11 +498,7 @@ public class WHSheetViewController: UIViewController {
         }
 
         delegate?.scrollChanged(frame: contentViewController.view.frame, state: gesture.state)
-        
-        self.pullBarBackgroundColor = UIColor.clear
-        self.gripColor = UIColor(white: 0.868, black: 0.1)
-        self.cornerRadius = 12
-        
+
         switch gesture.state {
         case .cancelled, .failed:
             self.contentViewController.view.layer.removeAllAnimations()
@@ -629,6 +631,10 @@ public class WHSheetViewController: UIViewController {
             if newSize == .fullscreen {
                 self.gripColor = self.childViewController.whSheetViewController?.overlayColor
                 self.cornerRadius = 0
+            } else {
+                self.gripColor = self.prePanGripColor
+                self.pullBarBackgroundColor = self.prePanPullBarBackgroundColor
+                self.cornerRadius = self.prePanCornerRadius
             }
 
             let previousSize = self.currentSize


### PR DESCRIPTION
before

https://github.com/user-attachments/assets/15d21ee6-51ef-4f0b-8f04-ac2ab6c66624

after


https://github.com/user-attachments/assets/4f72c460-49a4-413a-9328-1f5bdfd5e0fe



# 概要
パン（スワイプ）操作時に`gripColor`、`pullBarBackgroundColor`、`cornerRadius`がハードコードされたデフォルト値にリセットされるバグを修正。

## 問題
`panned(_:)`メソッド内で、`switch gesture.state`の**前**に以下のコードが毎回実行されていた：

```swift
self.pullBarBackgroundColor = UIColor.clear
self.gripColor = UIColor(white: 0.868, black: 0.1)
self.cornerRadius = 12
```

これにより、呼び出し元が設定したカスタム`gripColor`がスワイプ開始と同時にハードコードされたグレーに上書きされていた。

## 修正内容
- パン開始時（`.began`）に現在の`gripColor`/`pullBarBackgroundColor`/`cornerRadius`を保存
- ハードコードされたリセット処理を削除
- パン終了時（`.ended`）にfullscreen以外の場合は保存した値を復元

# 変更点
- `WHSheetViewController.swift`
  - `prePanGripColor`、`prePanPullBarBackgroundColor`、`prePanCornerRadius`プロパティを追加
  - `.began`で現在値を保存
  - `.ended`のnon-fullscreenブランチで保存した値を復元
  - 毎フレーム実行されていたハードコードリセットを削除

# やってないこと
- なし

# 行なった動作確認
- カスタム`gripColor`を設定したシートをスワイプしても色がリセットされないことを確認

# その他
- fullscreenへの遷移時の既存挙動（`gripColor`をoverlayColorに、`cornerRadius`を0に設定）は変更なし
- `.cancelled`/`.failed`ケースはハードコードリセットの削除により自然に修正される（mid-panでの値変更がなくなるため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)