### PR TITLE
fix: キーボード通知をfirst-responder所有権でフィルタする

### DIFF
--- a/Sources/WHSheetViewController/WHSheetViewController.swift
+++ b/Sources/WHSheetViewController/WHSheetViewController.swift
@@ -708,7 +708,16 @@ public class WHSheetViewController: UIViewController {
     }
 
     private func adjustForKeyboard(height: CGFloat, from notification: Notification) {
-        guard self.autoAdjustToKeyboard, let info:[AnyHashable: Any] = notification.userInfo else { return }
+        // Keyboard notifications are global — every WHSheet receives every event.
+        // We own this event if the first responder is currently in our subtree, OR if
+        // it's a hide event and we previously had a non-zero keyboardHeight (meaning
+        // we accepted the matching show earlier — the responder has since resigned, so
+        // the subtree walk would miss it, but we still need to resize back).
+        guard self.autoAdjustToKeyboard,
+              let info: [AnyHashable: Any] = notification.userInfo,
+              (self.viewIfLoaded?.containsFirstResponderInSubtree == true)
+                || (height == 0 && self.keyboardHeight > 0)
+        else { return }
         self.keyboardHeight = height
 
         let duration:TimeInterval = (info[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
@@ -1002,4 +1011,11 @@ extension WHSheetViewController: UIViewControllerTransitioningDelegate {
 
 public protocol WHSheetViewDelegate: AnyObject {
     func scrollChanged(frame:CGRect, state:UIGestureRecognizer.State)
+}
+
+fileprivate extension UIView {
+    var containsFirstResponderInSubtree: Bool {
+        if isFirstResponder { return true }
+        return subviews.contains(where: { $0.containsFirstResponderInSubtree })
+    }
 }


### PR DESCRIPTION
## 概要

グローバルなキーボード通知はメモリ内のすべての `WHSheetViewController` インスタンスに配信されます。各シートが各イベントを「自分のものか」を判定するロジックを追加します。

## オーナーシップの判定

キーボードイベントは以下の場合「このシートのもの」:

- **show / change イベント**: first responder が自分のsubtree内にある
- **hide イベント**: 直前に `keyboardHeight > 0` だった（= 対応する show を accept していた）。hide 時には responder が既に resign しているため subtree walk は使えないが、リサイズは戻す必要がある

```swift
guard self.autoAdjustToKeyboard,
      let info: [AnyHashable: Any] = notification.userInfo,
      (self.viewIfLoaded?.containsFirstResponderInSubtree == true)
        || (height == 0 && self.keyboardHeight > 0)
else { return }
```

`fileprivate extension UIView { var containsFirstResponderInSubtree: Bool { ... } }` でsubtree walkヘルパーを追加。

## 経緯

最初は `viewIfLoaded?.window != nil && presentedViewController == nil` の二重ガードで「フォアグラウンド時のみ反応」としていました（前のコミット `ed2fa5c`）。これでも基本ケースは動きますが、レビュー（@michael）で **state staleness** の懸念が挙がりました:

> Sheet A がキーボードを保持中にmodalを present → Aがバックグラウンドに → Aのキーボードが消える hide イベントが flagged out される → A の `keyboardHeight` が 250 のまま残る → modal を閉じると A は存在しないキーボード分だけサイズが大きい

whoo-ios のコードベースを監査したところ、まさにこのケースが現存していました:

- `WhooChatRoomListViewController` (チャットリスト) は検索バー（own keyboard）を持ち、かつタップでチャット画面（modal）を present する
- 検索 → タップでチャット遷移 → 戻ると、リストの下部にキーボード分の白い空白が残る

そのためガードを first-responder 所有権ベースの判定に置き換えます。

## 影響範囲

- 通常の単独シートの動作: 変更なし（subtree walk が responder を捕捉）
- バックグラウンドシートが他VCのキーボードに反応する旧バグ: 修正済み（subtree walk が miss する）
- own keyboard + modal present の組み合わせ: 修正済み（hide イベントが `keyboardHeight > 0` 経由で accept される）

## テスト

- [ ] 単独 WHSheet 内でテキスト入力 → キーボード追従動作が正常
- [ ] WHSheet の上にモーダル提示 → モーダル内でキーボード入力 → モーダル dismiss 時に背後シートがリサイズしない
- [ ] **own keyboard + modal scenario**: チャットリスト → 検索バーで入力 → チャット遷移 → 戻る → 下部に白い空白が残らない
- [ ] 同じシートを複数表示するスタッキング動作が影響を受けない
- [ ] hardware keyboard のみ使用時にクラッシュしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)